### PR TITLE
Added Union of 2 cases

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.Data.MsSql/Queries/GameResultQueries.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Data.MsSql/Queries/GameResultQueries.cs
@@ -69,25 +69,45 @@
         /// <returns>List of domain models of game result.</returns>
         public List<GameResultDto> Execute(TournamentGameResultsCriteria criteria)
         {
-            var query =
-                (from game in _dalGameResults
-                 join tournament in _dalTournaments
-                     on game.TournamentId equals tournament.Id
-                 join division in _dalDivisions
-                     on tournament.Id equals division.TournamentId
-                 join groups in _dalGroups
-                     on division.Id equals groups.DivisionId
-                 where game.TournamentId == criteria.TournamentId
-                 select new
-                 {
-                     results = game,
-                     divisionName = division.Name,
-                     divisionId = division.Id,
-                     groupId = groups.Id
-                 })
-                // Distinct by game id
-                .GroupBy(p => p.results.Id)
-                .Select(group => group.FirstOrDefault());
+            var tournamentId = criteria.TournamentId;
+
+            var allGamesWithTeams =
+                from game in _dalGameResults
+                join tournament in _dalTournaments
+                    on game.TournamentId equals tournament.Id
+                join division in _dalDivisions
+                    on tournament.Id equals division.TournamentId
+                join groups in _dalGroups
+                    on division.Id equals groups.DivisionId
+                where game.TournamentId == tournamentId
+                where groups.Teams.Contains(game.HomeTeam)
+                select new
+                {
+                    results = game,
+                    divisionName = division.Name,
+                    divisionId = division.Id,
+                    groupId = groups.Id
+                };
+
+            var gamesWithoutTeams =
+                from game in _dalGameResults
+                join tournament in _dalTournaments
+                    on game.TournamentId equals tournament.Id
+                join division in _dalDivisions
+                    on tournament.Id equals division.TournamentId
+                join groups in _dalGroups
+                    on division.Id equals groups.DivisionId
+                where game.TournamentId == tournamentId
+                where game.HomeTeam == null
+                select new
+                {
+                    results = game,
+                    divisionName = division.Name,
+                    divisionId = division.Id,
+                    groupId = groups.Id
+                };
+
+            var query = allGamesWithTeams.Union(gamesWithoutTeams);
 
             List<GameResultDto> list = query.ToList()
                         .ConvertAll(item => Map(item.results, item.divisionName, item.divisionId, item.groupId));


### PR DESCRIPTION
### Summary

Second query addresses case with playoff scheme. When we add teams to the playoff tournament system creates placeholders for all games. But we don't know all teams for them at that point.

closes #136 

### Checklist

#### Design

- [x] Web API layer contains as little logic as possible
- [x] Domain objects use semantic names

#### Perfromance

- [x] In case of any DB query was changed: attach generated SQL for review
- [x] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [x] Naming: Initial state and expected result are properly stated
- [x] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [x] Test is Isolated
- [x] Mock instances and expected instances do not share references
