### PR TITLE
Change group selector when only 1 group

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Scripts/VMScripts/TournamentOperations/AddTeams.js
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Scripts/VMScripts/TournamentOperations/AddTeams.js
@@ -168,13 +168,15 @@ $(document).ready(function () {
         }
 
         privates.getAllGroupsOptions(function (options) {
-
-            var responseOptions = "<option value = '0'>" + currNs.groupIsNotSelectedMessage + "</option>";
-
-            $.each(options, function (key, value) {
-                responseOptions += "<option value='" + value.Id + "'>" + value.Name + "</option>";
-            });
-       
+            if (options.length == 1) {
+                var responseOptions = "<option value ='" + options[0].Id + "'>" + options[0].Name + "</option>";
+            }
+            else {
+                var responseOptions = "<option value = '0'>" + currNs.groupIsNotSelectedMessage + "</option>";
+                $.each(options, function (key, value) {
+                    responseOptions += "<option value='" + value.Id + "'>" + value.Name + "</option>";
+                });
+            }
             privates.RemoveGroupsAndDeleteRowButtonMarkup();
             privates.renderNewTournamentGroupsRow(responseOptions);
             $(".deleteTeamButton").bind("click", currNs.onDeleteTeamButtonClick);


### PR DESCRIPTION
### Summary

_add 1 condition when only 1 group for select. if(options.length==1) so in  UI automatically take this group 
closes #138

### Areas Of Interest
it is a subtask of main task #62

do not sure that these functions work correctly for loading groups in the selector
![image](https://user-images.githubusercontent.com/33187342/36150456-76ff9f28-10cc-11e8-99d1-0230dc7371b9.png)

previously function use this function, but without "change" in division selector it is doesn`t work. 
![image](https://user-images.githubusercontent.com/33187342/36150407-48698cd2-10cc-11e8-852e-ce463d7a040e.png)
  so we afraid that our decision has the same way, it is working correctly if we do not need a reaction to changing group selector
### Checklist


#### Design
![image](https://user-images.githubusercontent.com/33187342/36150824-a72a9b84-10cd-11e8-85a3-515ba452373f.png)
![image](https://user-images.githubusercontent.com/33187342/36150834-b5ddb7ce-10cd-11e8-9d54-a2c614ed7b91.png)


#### Perfromance

no change i DB

#### Unit Tests
Work good)
- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
