### PR TITLE
Fix wrong name for PlayOff scheme

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/ViewModels/Tournaments/TournamentViewModel.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/ViewModels/Tournaments/TournamentViewModel.cs
@@ -38,7 +38,7 @@
         /// Gets or sets the list of possible tournament schemes.
         /// </summary>
         /// <value>The list of tournament schemes.</value>
-        public List<int> TournamentSchemeList { get; set; }
+        public List<string> TournamentSchemeList { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating where Id.
@@ -279,13 +279,20 @@
         /// </summary>
         private void InitializeTournamentSchemeList()
         {
-            TournamentSchemeList = new List<int>();
+            TournamentSchemeList = new List<string>();
 
             foreach (TournamentSchemeEnum scheme in Enum.GetValues(typeof(TournamentSchemeEnum)))
             {
-                if (scheme != TournamentSchemeEnum.TwoAndHalf)
+                switch (scheme)
                 {
-                    TournamentSchemeList.Add((int)scheme);
+                    case TournamentSchemeEnum.TwoAndHalf:
+                        break;
+                    case TournamentSchemeEnum.PlayOff:
+                        TournamentSchemeList.Add(scheme.ToString());
+                        break;
+                    default:
+                        TournamentSchemeList.Add(((int)scheme).ToString());
+                        break;
                 }
             }
         }


### PR DESCRIPTION
### Summary

Changed type of list which include all possible tournaments schemes.
Also I made some corrections in InitializeTournamentSchemeList() method.


### Checklist

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
