### PR TITLE
Add edit option to day off game in PlayOff

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
@@ -1,4 +1,6 @@
 ﻿@model VolleyManagement.UI.Areas.Mvc.ViewModels.GameResults.GameResultViewModel
+@using VolleyManagement.Domain.RolesAggregate;
+@using VolleyManagement.UI.Areas.Mvc.ViewModels.Tournaments;
 
 <div class="table-bordered">
 
@@ -74,11 +76,14 @@
                     @Resources.UI.TournamentViews.TeamDayOff
                 </div>
             </div>
-            <div class="row">
-                <div class="col-md-2">
-                    @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+            if (Model.AllowedOperations.IsAllowed(AuthOperations.Games.Edit))
+            {
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                    </div>
                 </div>
-            </div>
+            }
         }
         else
         {

--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
@@ -1,6 +1,4 @@
 ﻿@model VolleyManagement.UI.Areas.Mvc.ViewModels.GameResults.GameResultViewModel
-@using VolleyManagement.Domain.RolesAggregate;
-@using VolleyManagement.UI.Areas.Mvc.ViewModels.Tournaments;
 
 <div class="table-bordered">
 
@@ -76,7 +74,7 @@
                     @Resources.UI.TournamentViews.TeamDayOff
                 </div>
             </div>
-            if (Model.AllowedOperations.IsAllowed(AuthOperations.Games.Edit))
+            if (Model.AllowEditResult)
             {
                 <div class="row">
                     <div class="col-md-2">

--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
@@ -74,6 +74,11 @@
                     @Resources.UI.TournamentViews.TeamDayOff
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-2">
+                    @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                </div>
+            </div>
         }
         else
         {


### PR DESCRIPTION
### Summary

Add admin possibility to edit Day Off game in first round of PlayOff tournament.

### Areas Of Interest

### Checklist

#### Design

- [x] Web API layer contains as little logic as possible
- [x] Domain objects use semantic names

#### Perfromance

- [x] In case of any DB query was changed: attach generated SQL for review
- [x] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [x] Naming: Initial state and expected result are properly stated
- [x] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [x] Test is Isolated
- [x] Mock instances and expected instances do not share references
