### PR TITLE
Issue #169 cannot set time for the future game in playoff

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
@@ -341,15 +341,15 @@
 
         private void ValidateTeams(int? homeTeamId, int? awayTeamId, TournamentScheduleDto tournamentScheduleInfo)
         {
-            if (tournamentScheduleInfo.Scheme != TournamentSchemeEnum.PlayOff
-                && GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
+            if (tournamentScheduleInfo.Scheme == TournamentSchemeEnum.PlayOff)
             {
-                throw new ArgumentException(Resources.GameResultSameTeam);
+                if (!(homeTeamId == null && awayTeamId == null) &&
+                    GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
+                {
+                    throw new ArgumentException(Resources.GameResultSameTeam);
+                }
             }
-
-            if (tournamentScheduleInfo.Scheme == TournamentSchemeEnum.PlayOff
-                && !(homeTeamId == null && awayTeamId == null) 
-                && GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
+            else if (GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
             {
                 throw new ArgumentException(Resources.GameResultSameTeam);
             }

--- a/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
@@ -327,7 +327,7 @@
 
         private void ValidateGame(Game game, TournamentScheduleDto tournamentScheduleInfo)
         {
-            ValidateTeams(game.HomeTeamId, game.AwayTeamId);
+            ValidateTeams(game.HomeTeamId, game.AwayTeamId, tournamentScheduleInfo);
             ValidateGameInTournament(game, tournamentScheduleInfo);
         }
 
@@ -339,9 +339,17 @@
             ValidateSetScoresOrder(result.SetScores);
         }
 
-        private void ValidateTeams(int? homeTeamId, int? awayTeamId)
+        private void ValidateTeams(int? homeTeamId, int? awayTeamId, TournamentScheduleDto tournamentScheduleInfo)
         {
-            if (GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
+            if (tournamentScheduleInfo.Scheme != TournamentSchemeEnum.PlayOff
+                && GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
+            {
+                throw new ArgumentException(Resources.GameResultSameTeam);
+            }
+
+            if (tournamentScheduleInfo.Scheme == TournamentSchemeEnum.PlayOff
+                && !(homeTeamId == null && awayTeamId == null) 
+                && GameValidation.AreTheSameTeams(homeTeamId, awayTeamId))
             {
                 throw new ArgumentException(Resources.GameResultSameTeam);
             }
@@ -469,8 +477,15 @@
                     TournamentId = tournamentSсheduleInfo.Id
                 });
 
-            var newGameDivisionId = teamsInTournament
-                .First(t => t.TeamId == newGame.AwayTeamId || t.TeamId == newGame.HomeTeamId).DivisionId;
+            var newGameDivisionId = (int?)0;
+
+            if (!(newGame.AwayTeamId == null && newGame.HomeTeamId == null && tournamentSсheduleInfo.Scheme == TournamentSchemeEnum.PlayOff))
+            {
+                newGameDivisionId = teamsInTournament
+                    .First(t => t.TeamId == newGame.AwayTeamId || t.TeamId == newGame.HomeTeamId).DivisionId;
+            }
+
+
 
             var gamesInSameRoundSameDivision = (
                         from game in games

--- a/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
@@ -479,13 +479,11 @@
 
             var newGameDivisionId = (int?)0;
 
-            if (!(newGame.AwayTeamId == null && newGame.HomeTeamId == null && tournamentSсheduleInfo.Scheme == TournamentSchemeEnum.PlayOff))
+            if (IsNotPlayOffThemeAndBothTeamsNotNull(newGame, tournamentSсheduleInfo))
             {
                 newGameDivisionId = teamsInTournament
                     .First(t => t.TeamId == newGame.AwayTeamId || t.TeamId == newGame.HomeTeamId).DivisionId;
             }
-
-
 
             var gamesInSameRoundSameDivision = (
                         from game in games
@@ -502,6 +500,13 @@
                 newGame,
                 gamesInSameRoundSameDivision,
                 tournamentSсheduleInfo);
+        }
+
+        private static bool IsNotPlayOffThemeAndBothTeamsNotNull(Game newGame, TournamentScheduleDto tournamentSсheduleInfo)
+        {
+            return !(newGame.AwayTeamId == null &&
+                     newGame.HomeTeamId == null && 
+                     tournamentSсheduleInfo.Scheme == TournamentSchemeEnum.PlayOff);
         }
 
         private static void ValidateGameInRoundOnCreate(

--- a/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameServiceTestFixture.cs
+++ b/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameServiceTestFixture.cs
@@ -913,6 +913,54 @@
             return this;
         }
 
+        public GameServiceTestFixture TestTeamsEqualsPlayOffScheme()
+        {
+            _gameResults.Clear();
+
+            _gameResults.AddRange(
+                new List<GameResultDto>
+                {
+                    new GameResultDto
+                    {
+                        Id = 1,
+                        HomeTeamId = 1,
+                        AwayTeamId = 1,
+                        GameNumber = 1,
+                        Round = 1,
+                        TournamentId = 1,
+                        UrlToGameVideo = URL_A,
+                    },
+                    new GameResultDto
+                    {
+                        Id = 2,
+                        HomeTeamId = 3,
+                        AwayTeamId = 4,
+                        GameNumber = 2,
+                        Round = 1,
+                        TournamentId = 1,
+                        UrlToGameVideo = URL_B,
+                    },
+                    new GameResultDto
+                    {
+                        Id = 3,
+                        Round = 2,
+                        GameNumber = 3,
+                        TournamentId = 1,
+                        UrlToGameVideo = URL_C,
+                    },
+                    new GameResultDto
+                    {
+                        Id = 4,
+                        Round = 2,
+                        GameNumber = 4,
+                        TournamentId = 1,
+                        UrlToGameVideo = URL_D,
+                    },
+                });
+
+            return this;
+        }
+
         /// <summary>
         /// Builds instance of <see cref="GameServiceTestFixture"/>.
         /// </summary>

--- a/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameServiceTestFixture.cs
+++ b/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameServiceTestFixture.cs
@@ -913,7 +913,7 @@
             return this;
         }
 
-        public GameServiceTestFixture TestTeamsEqualsPlayOffScheme()
+        public GameServiceTestFixture SameTeamsInOneGamePlayOffScheme()
         {
             _gameResults.Clear();
 

--- a/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameTestFixture.cs
+++ b/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameTestFixture.cs
@@ -209,7 +209,7 @@
             return this;
         }
 
-        public GameTestFixture TestTeamsEqualsPlayOffScheme()
+        public GameTestFixture SameTeamsInOneGamePlayOffScheme()
         {
             _games.Clear();
 

--- a/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameTestFixture.cs
+++ b/tests/VolleyManagement.UnitTests/Services/GameService/Fixture/GameTestFixture.cs
@@ -209,6 +209,54 @@
             return this;
         }
 
+        public GameTestFixture TestTeamsEqualsPlayOffScheme()
+        {
+            _games.Clear();
+
+            _games.AddRange(
+                new List<Game>
+                {
+                    new Game
+                    {
+                        Id = 1,
+                        HomeTeamId = 1,
+                        AwayTeamId = 1,
+                        GameNumber = 1,
+                        Round = 1,
+                        TournamentId = 1,
+                        Result = new Result()
+                    },
+                    new Game
+                    {
+                        Id = 2,
+                        HomeTeamId = 3,
+                        AwayTeamId = 4,
+                        GameNumber = 2,
+                        Round = 1,
+                        TournamentId = 1,
+                        Result = new Result()
+                    },
+                    new Game
+                    {
+                        Id = 3,
+                        Round = 2,
+                        GameNumber = 3,
+                        TournamentId = 1,
+                        Result = new Result()
+                    },
+                    new Game
+                    {
+                        Id = 4,
+                        Round = 2,
+                        GameNumber = 4,
+                        TournamentId = 1,
+                        Result = new Result()
+                    }
+                });
+
+            return this;
+        }
+
         public GameTestFixture TestMinimumOddTeamsPlayOffSchedule()
         {
             _games.Clear();

--- a/tests/VolleyManagement.UnitTests/Services/GameService/GameServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/GameService/GameServiceTests.cs
@@ -1646,6 +1646,10 @@
                 Times.AtLeastOnce());
         }
 
+        /// <summary>
+        /// Test method checks that 2 same teams(not null) can't be in one game in PlayOff scheme.
+        /// Argument exception thrown. 
+        /// </summary>
         [TestMethod]
         public void Edit_BothTeamsEqualInPlayOff_ArgumentExceptionThrown()
         {
@@ -1653,11 +1657,11 @@
 
             // Arrange
             var games = new GameTestFixture()
-                .TestTeamsEqualsPlayOffScheme()
+                .SameTeamsInOneGamePlayOffScheme()
                 .Build();
 
             var gameInfo = new GameServiceTestFixture()
-                .TestTeamsEqualsPlayOffScheme()
+                .SameTeamsInOneGamePlayOffScheme()
                 .Build();
 
             MockTournamentSchemePlayoff(
@@ -1694,11 +1698,11 @@
             MockDefaultTournament();
 
             var games = new GameTestFixture()
-                .TestTeamsEqualsPlayOffScheme()
+                .SameTeamsInOneGamePlayOffScheme()
                 .Build();
 
             var gameInfo = new GameServiceTestFixture()
-                .TestTeamsEqualsPlayOffScheme()
+                .SameTeamsInOneGamePlayOffScheme()
                 .Build();
 
             MockTournamentSchemePlayoff(


### PR DESCRIPTION
### Summary

Modify teams validation in game for Play Off scheme.

closes #169

### Checklist

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
