### PR TITLE
Issue #209 number of games double in play off

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/GameService.cs
@@ -314,7 +314,8 @@
         /// <param name="tournamentId">Identifier of the tournament</param>
         public void RemoveAllGamesInTournament(int tournamentId)
         {
-            var gamesToRemove = GetTournamentResults(tournamentId);
+            //var gamesToRemove = GetTournamentResults(tournamentId);
+            var gamesToRemove = QueryAllTournamentGames(tournamentId);
             foreach (var game in gamesToRemove)
             {
                 _gameRepository.Remove(game.Id);

--- a/src/VolleyManagement.Backend/VolleyManagement.Services/TournamentRequestService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/TournamentRequestService.cs
@@ -21,7 +21,7 @@
     {
         private readonly IMailService _mailService;
         private readonly ITournamentRequestRepository _tournamentRequestRepository;
-        private readonly ITournamentRepository _tournamentRepository;
+        private readonly ITournamentService _tournamentService;
         private readonly IAuthorizationService _authService;
         private readonly IQuery<List<TournamentRequest>, GetAllCriteria> _getAllTournamentRequestsQuery;
         private readonly IQuery<TournamentRequest, FindByIdCriteria> _getTournamentRequestByIdQuery;
@@ -45,7 +45,7 @@
             IQuery<List<TournamentRequest>, GetAllCriteria> getAllTournamentRequestsQuery,
             IQuery<TournamentRequest, FindByIdCriteria> getTournamentRequestById,
             IQuery<TournamentRequest, FindByTeamTournamentCriteria> getTournamentRequestByAll,
-            ITournamentRepository tournamentRepository,
+            ITournamentService tournamentService,
             IMailService mailService,
             IUserService userService)
         {
@@ -54,7 +54,7 @@
             _getAllTournamentRequestsQuery = getAllTournamentRequestsQuery;
             _getTournamentRequestByIdQuery = getTournamentRequestById;
             _getTournamentRequestByAllQuery = getTournamentRequestByAll;
-            _tournamentRepository = tournamentRepository;
+            _tournamentService = tournamentService;
             _mailService = mailService;
             _userService = userService;
         }
@@ -73,9 +73,16 @@
                 throw new MissingEntityException(ServiceResources.ExceptionMessages.TournamentRequestNotFound, requestId);
             }
 
-            _tournamentRepository.AddTeamToTournament(tournamentRequest.TeamId, tournamentRequest.GroupId);
-            _tournamentRepository.UnitOfWork.Commit();
-             NotifyUser(_userService.GetUser(Get(requestId).UserId).Email);
+            _tournamentService.AddTeamsToTournament(new List<TeamTournamentAssignmentDto>
+                                                        {
+                                                            new TeamTournamentAssignmentDto
+                                                            {
+                                                                TeamId = tournamentRequest.TeamId,
+                                                                GroupId = tournamentRequest.GroupId
+                                                            }
+                                                        });
+
+            NotifyUser(_userService.GetUser(Get(requestId).UserId).Email);
             _tournamentRequestRepository.Remove(requestId);
             _tournamentRequestRepository.UnitOfWork.Commit();
         }

--- a/src/VolleyManagement.Backend/VolleyManagement.Services/TournamentService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/TournamentService.cs
@@ -742,14 +742,28 @@
         private void CreateSchedule(int tournamentId, int allTeamsCount)
         {
             var tournament = Get(tournamentId);
-            if (tournament.Scheme == TournamentSchemeEnum.PlayOff)
+            if (tournament.Scheme == TournamentSchemeEnum.PlayOff
+                && allTeamsCount > DONT_CREATE_SCHEDULE_TEAMS_COUNT)
             {
-                if (allTeamsCount > DONT_CREATE_SCHEDULE_TEAMS_COUNT)
+                var gamesToAdd = GetAllGamesInPlayOffTournament(tournamentId, allTeamsCount);
+
+                var existGames = _gameService.GetTournamentGames(tournamentId).Where(tr => !(tr.GameDate == null)).ToList();
+
+                GameResultDto game;
+                int count = existGames.Count;
+                for (int i = 0; i < count; i++)
                 {
-                    var gamesToAdd = GetAllGamesInPlayOffTournament(tournamentId, allTeamsCount);
-                    _gameService.RemoveAllGamesInTournament(tournamentId);
-                    _gameService.AddGames(gamesToAdd);
+                    game = existGames[i];
+                    gamesToAdd[i].GameDate = game.GameDate;
+                    gamesToAdd[i].UrlToGameVideo = game.UrlToGameVideo;
+                    gamesToAdd[i].Result = game.Result;
+                    gamesToAdd[i].AwayTeamId = game.AwayTeamId;
+                    gamesToAdd[i].HomeTeamId = game.HomeTeamId;
+                    gamesToAdd[i].TournamentId = game.TournamentId;
                 }
+
+                _gameService.RemoveAllGamesInTournament(tournamentId);
+                _gameService.AddGames(gamesToAdd);
             }
         }
 

--- a/tests/VolleyManagement.UnitTests/Services/TournamentRequestService/TournamentRequestServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TournamentRequestService/TournamentRequestServiceTests.cs
@@ -14,7 +14,6 @@
     using Data.Queries.TournamentRequest;
     using Domain.RolesAggregate;
     using Domain.TournamentRequestAggregate;
-    using Domain.TournamentsAggregate;
     using Domain.UsersAggregate;
     using MailService;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -38,7 +37,7 @@
         private Mock<IQuery<List<TournamentRequest>, GetAllCriteria>> _getAllRequestsQueryMock;
         private Mock<IQuery<TournamentRequest, FindByIdCriteria>> _getRequestByIdQueryMock;
         private Mock<IQuery<TournamentRequest, FindByTeamTournamentCriteria>> _getRequestByAllQueryMock;
-        private Mock<ITournamentRepository> _tournamentRepositoryMock;
+        private Mock<ITournamentService> _tournamentServiceMock = new Mock<ITournamentService>();
         private Mock<IMailService> _mailServiceMock;
         private Mock<IUserService> _userServiceMock;
 
@@ -58,14 +57,12 @@
 
             _getRequestByAllQueryMock = new Mock<IQuery<TournamentRequest, FindByTeamTournamentCriteria>>();
 
-            _tournamentRepositoryMock = new Mock<ITournamentRepository>();
+            _tournamentServiceMock = new Mock<ITournamentService>();
 
             _mailServiceMock = new Mock<IMailService>();
 
             _userServiceMock = new Mock<IUserService>();
 
-            _tournamentRepositoryMock.Setup(tr => tr.UnitOfWork)
-                    .Returns(_unitOfWorkMock.Object);
             _tournamentRequestRepositoryMock.Setup(tr => tr.UnitOfWork)
                 .Returns(_unitOfWorkMock.Object);
         }
@@ -210,7 +207,9 @@
             // Arrange
             var expected = new TournamentRequestBuilder().WithId(EXISTING_ID).Build();
             MockGetRequestByIdQuery(expected);
-            _tournamentRepositoryMock.Setup(tr => tr.AddTeamToTournament(It.IsAny<int>(), It.IsAny<int>()));
+
+            _tournamentServiceMock.Setup(tr => tr.AddTeamsToTournament(It.IsAny<List<TeamTournamentAssignmentDto>>()));
+
             var emailMessage = new EmailMessageBuilder().Build();
             MockGetUser();
             MockRemoveTournamentRequest();
@@ -221,7 +220,7 @@
             sut.Confirm(EXISTING_ID);
 
             // Assert
-            VerifyAddedTeam(expected.Id, expected.TournamentId, expected.GroupId, Times.Once(), Times.AtLeastOnce());
+            VerifyAddedTeam(Times.Once());
         }
 
         [TestMethod]
@@ -291,7 +290,7 @@
                 _getAllRequestsQueryMock.Object,
                 _getRequestByIdQueryMock.Object,
                 _getRequestByAllQueryMock.Object,
-                _tournamentRepositoryMock.Object,
+                _tournamentServiceMock.Object,
                 _mailServiceMock.Object,
                 _userServiceMock.Object);
         }
@@ -330,10 +329,9 @@
             _getRequestByAllQueryMock.Setup(tr => tr.Execute(It.IsAny<FindByTeamTournamentCriteria>())).Returns(testData);
         }
 
-        private void VerifyAddedTeam(int requestId, int tournamentId, int groupId, Times times, Times unitOfWorkTimes)
+        private void VerifyAddedTeam(Times times)
         {
-            _tournamentRepositoryMock.Verify(tr => tr.AddTeamToTournament(requestId, groupId), times);
-            _unitOfWorkMock.Verify(uow => uow.Commit(), unitOfWorkTimes);
+            _tournamentServiceMock.Verify(tr => tr.AddTeamsToTournament(It.IsAny<List<TeamTournamentAssignmentDto>>()), times);
         }
 
         private void MockAuthServiceThrownException(AuthOperation operation)


### PR DESCRIPTION
### Summary

In CreateSchedule modify method GetAllGamesInPlayOffTournament(to add scheduled game in new schedule), and change RemoveAllGamesInTournament( to remove all games from schedule, but  not only games that have result)

closes #209

### Areas Of Interest

Not sure that this solve is good, so that why I create pull requst, before start fix 3 failed test.
Why RemoveAllGamesInTournament remove only games, that have result? 

### Checklist

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
- [ ] When new property is added all related comparers are updated
