### PR TITLE
Fix bug in issue #218

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
@@ -5,278 +5,278 @@
 
     @if (!Model.HomeTeamId.HasValue && !Model.AwayTeamId.HasValue)
     {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
-                <div class="row">
-                    <strong> @Model.HomeTeamName </strong>
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-3 game-number">
+                    <strong>@Model.DisplayGameNumber </strong>
                 </div>
-                <div class="row">
-                    <strong> @Model.AwayTeamName </strong>
+                <div class="col-md-7">
+                    <div class="row">
+                        <strong> @Model.HomeTeamName </strong>
+                    </div>
+                    <div class="row">
+                        <strong> @Model.AwayTeamName </strong>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
         if (Model.GameDate.HasValue)
         {
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Model.ShortGameDate
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-10 text-right">
+                    @Model.ShortGameDate
+                </div>
+            </div>
         }
 
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+        <div class="row">
+            <div class="col-md-2">
+                @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+            </div>
         </div>
-    </div>
     }
     else if (!Model.HomeTeamId.HasValue && Model.AwayTeamId.HasValue)
     {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
-                <div class="row">
-                    <strong>   @Resources.UI.TournamentViews.HomeTeamPlaceholder </strong>
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-3 game-number">
+                    <strong>@Model.DisplayGameNumber </strong>
                 </div>
-                <div class="row">
-                    <strong>  @Model.AwayTeamName </strong>
+                <div class="col-md-7">
+                    <div class="row">
+                        <strong>   @Resources.UI.TournamentViews.HomeTeamPlaceholder </strong>
+                    </div>
+                    <div class="row">
+                        <strong>  @Model.AwayTeamName </strong>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
         if (Model.GameDate.HasValue)
         {
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Model.ShortGameDate
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-10 text-right">
+                    @Model.ShortGameDate
+                </div>
+            </div>
         }
 
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+        <div class="row">
+            <div class="col-md-2">
+                @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+            </div>
         </div>
-    </div>
     }
     else if (Model.HomeTeamId.HasValue && !Model.AwayTeamId.HasValue)
     {
         if (Model.IsFirstRoundGame)
         {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3">
-                <strong>@Model.DisplayGameNumber </strong>
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-md-3">
+                        <strong>@Model.DisplayGameNumber </strong>
+                    </div>
+                    <div class="col-md-7">
+                        <strong>   @Model.HomeTeamName </strong>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-7">
-                <strong>   @Model.HomeTeamName </strong>
-            </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Resources.UI.TournamentViews.TeamDayOff
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-10 text-right">
+                    @Resources.UI.TournamentViews.TeamDayOff
+                </div>
+            </div>
 
             if (Model.AllowedOperations.IsAllowed(AuthOperations.Games.Edit))
             {
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                    </div>
+                </div>
             }
         }
         else
         {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
+            <div class="container-fluid">
                 <div class="row">
-                    <strong>   @Model.HomeTeamName </strong>
-                </div>
-                <div class="row">
-                    <strong>  @Resources.UI.TournamentViews.AwayTeamPlaceholder </strong>
+                    <div class="col-md-3 game-number">
+                        <strong>@Model.DisplayGameNumber </strong>
+                    </div>
+                    <div class="col-md-7">
+                        <div class="row">
+                            <strong>   @Model.HomeTeamName </strong>
+                        </div>
+                        <div class="row">
+                            <strong>  @Resources.UI.TournamentViews.AwayTeamPlaceholder </strong>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
 
             if (Model.GameDate.HasValue)
             {
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Model.ShortGameDate
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-10 text-right">
+                        @Model.ShortGameDate
+                    </div>
+                </div>
             }
         }
 
         if (Model.AllowedOperations.IsAllowed(AuthOperations.Games.Edit))
         {
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-2">
+                    @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                </div>
+            </div>
         }
     }
     else if (Model.HomeTeamId.HasValue && Model.AwayTeamId.HasValue)
     {
         if (Model.IsTechnicalDefeat)
         {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
+            <div class="container-fluid">
                 <div class="row">
-                    <div class="row">
-                        <div class="col-md-10">
-                            <strong>  @Model.HomeTeamName </strong>
-                        </div>
-                        <div class="col-md-2">
-                            <strong>  @Model.GameScore.Home </strong>
-                        </div>
+                    <div class="col-md-3 game-number">
+                        <strong>@Model.DisplayGameNumber </strong>
                     </div>
-                    <div class="row">
-                        <div class="col-md-10">
-                            <strong>  @Model.AwayTeamName </strong>
-                        </div>
-                        <div class="col-md-2">
-                            <strong>  @Model.GameScore.Away </strong>
+                    <div class="col-md-7">
+                        <div class="row">
+                            <div class="row">
+                                <div class="col-md-10">
+                                    <strong>  @Model.HomeTeamName </strong>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>  @Model.GameScore.Home </strong>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-10">
+                                    <strong>  @Model.AwayTeamName </strong>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>  @Model.GameScore.Away </strong>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Resources.UI.GameResultViews.TechnicalDefeat
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-10 text-right">
+                    @Resources.UI.GameResultViews.TechnicalDefeat
+                </div>
+            </div>
 
             if (Model.AllowEditResult)
             {
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
+                    </div>
+                </div>
             }
         }
         else if (!Model.GameScore.IsEmpty)
         {
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
+            <div class="container-fluid">
                 <div class="row">
-                    <div class="row">
-                        <div class="col-md-10">
-                            <strong>  @Model.HomeTeamName </strong>
-                        </div>
-                        <div class="col-md-2">
-                            <strong>   @Model.GameScore.Home </strong>
-                        </div>
+                    <div class="col-md-3 game-number">
+                        <strong>@Model.DisplayGameNumber </strong>
                     </div>
-                    <div class="row">
-                        <div class="col-md-10">
-                            <strong>  @Model.AwayTeamName </strong>
-                        </div>
-                        <div class="col-md-2">
-                            <strong>  @Model.GameScore.Away </strong>
+                    <div class="col-md-7">
+                        <div class="row">
+                            <div class="row">
+                                <div class="col-md-10">
+                                    <strong>  @Model.HomeTeamName </strong>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>   @Model.GameScore.Home </strong>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-10">
+                                    <strong>  @Model.AwayTeamName </strong>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>  @Model.GameScore.Away </strong>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
 
-    <div class="row">
-        @foreach (var score in Model.SetScores)
+            <div class="row">
+                @foreach (var score in Model.SetScores)
                 {
                     if (!score.IsEmpty)
                     {
-        <div class="col-md-2">
-            @score.Home:@score.Away
-        </div>
+                        <div class="col-md-2">
+                            @score.Home:@score.Away
+                        </div>
                     }
                 }
-    </div>
+            </div>
 
             if (Model.AllowEditResult)
             {
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
+                    </div>
+                </div>
             }
         }
         else
         {
 
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 game-number">
-                <strong>@Model.DisplayGameNumber </strong>
-            </div>
-            <div class="col-md-7">
+            <div class="container-fluid">
                 <div class="row">
-                    <strong>  @Model.HomeTeamName </strong>
-                </div>
-                <div class="row">
-                    <strong>  @Model.AwayTeamName </strong>
+                    <div class="col-md-3 game-number">
+                        <strong>@Model.DisplayGameNumber </strong>
+                    </div>
+                    <div class="col-md-7">
+                        <div class="row">
+                            <strong>  @Model.HomeTeamName </strong>
+                        </div>
+                        <div class="row">
+                            <strong>  @Model.AwayTeamName </strong>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
 
             if (Model.GameDate.HasValue)
             {
-    <div class="row">
-        <div class="col-md-10 text-right">
-            @Model.ShortGameDate
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-10 text-right">
+                        @Model.ShortGameDate
+                    </div>
+                </div>
 
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
-        </div>
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Result, "Edit", "GameResults", new { Id = Model.Id }, null)
+                    </div>
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                    </div>
+                </div>
             }
             else
             {
-    <div class="row">
-        <div class="col-md-2">
-            @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
-        </div>
-    </div>
+                <div class="row">
+                    <div class="col-md-2">
+                        @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
+                    </div>
+                </div>
             }
         }
     }

--- a/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
+++ b/src/VolleyManagement.Backend/VolleyManagement.UI/Areas/Mvc/Views/Tournaments/_PlayoffGameResult.cshtml
@@ -89,15 +89,6 @@
                     @Resources.UI.TournamentViews.TeamDayOff
                 </div>
             </div>
-
-            if (Model.AllowedOperations.IsAllowed(AuthOperations.Games.Edit))
-            {
-                <div class="row">
-                    <div class="col-md-2">
-                        @Html.ActionLink(Resources.UI.TournamentViews.Edit, "EditScheduledGame", new { gameId = Model.Id })
-                    </div>
-                </div>
-            }
         }
         else
         {


### PR DESCRIPTION
### Summary

Fix bug in issue #218. When you manage dayOff as first game, two action links appear.
Schedule page before changes:
![image](https://user-images.githubusercontent.com/36235893/37662197-34578a56-2c5f-11e8-9311-c98d94f31338.png)

After changes:
![image](https://user-images.githubusercontent.com/36235893/37662214-4032214c-2c5f-11e8-8163-9a24f87e9b43.png)

### Areas Of Interest

It was fixed by editing file _PlayoffGameResult.cshtml. I have deleted excessive lines of code for the first round.
![image](https://user-images.githubusercontent.com/36235893/37662251-564e613e-2c5f-11e8-98fe-c4e70bdcb241.png)

### Checklist

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
- [ ] When new property is added all related comparers are updated
