### PR TITLE
Added test for AddPlayers and RemovePlayers in TeamService

### DIFF
--- a/src/VolleyManagement.Backend/VolleyManagement.Services/TeamService.cs
+++ b/src/VolleyManagement.Backend/VolleyManagement.Services/TeamService.cs
@@ -29,7 +29,6 @@
         private readonly IPlayerRepository _playerRepository;
         private readonly IQuery<Team, FindByIdCriteria> _getTeamByIdQuery;
         private readonly IQuery<Player, FindByIdCriteria> _getPlayerByIdQuery;
-        private readonly IQuery<Player, FindByFullNameCriteria> _getPlayerByNameQuery;
         private readonly IQuery<Team, FindByCaptainIdCriteria> _getTeamByCaptainQuery;
         private readonly IQuery<int, FindByPlayerCriteria> _getPlayerTeamQuery;
         private readonly IQuery<ICollection<Team>, GetAllCriteria> _getAllTeamsQuery;
@@ -68,7 +67,6 @@
             _playerRepository = playerRepository;
             _getTeamByIdQuery = getTeamByIdQuery;
             _getPlayerByIdQuery = getPlayerByIdQuery;
-            _getPlayerByNameQuery = getPlayerByNameQuery;
             _getTeamByCaptainQuery = getTeamByCaptainQuery;
             _getPlayerTeamQuery = getPlayerTeamQuery;
             _getAllTeamsQuery = getAllTeamsQuery;

--- a/tests/VolleyManagement.UnitTests/Mvc/Controllers/PlayersControllerTests.cs
+++ b/tests/VolleyManagement.UnitTests/Mvc/Controllers/PlayersControllerTests.cs
@@ -319,7 +319,9 @@
         {
             // Arrange
             var testData = MakeTestPlayerViewModel();
+            var player = MakeTestPlayer(1);
             var sut = BuildSUT();
+            SetupCreate(player);
 
             // Act
             var result = sut.Create(testData) as RedirectToRouteResult;
@@ -541,6 +543,11 @@
         private void SetupGet(int playerId, Player player)
         {
             _playerServiceMock.Setup(tr => tr.Get(playerId)).Returns(player);
+        }
+
+        private void SetupCreate(Player player)
+        {
+            _playerServiceMock.Setup(tr => tr.Create(It.IsAny<CreatePlayerDto>())).Returns(player);
         }
 
         private void SetupCreateThrowsArgumentException()

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -810,6 +810,538 @@
             VerifyEditTeam(teamToEdit, Times.Once());
         }
 
+        /// <summary>
+        /// Test for AddPlayers() method. 
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_AllPlayerNew_TeamUpdated()
+        {
+            // Arrange
+            var testPlayersIdToAdd = CreateSeveralPlayersId();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            var exeptedTeam = new TeamBuilder().WithRoster(testPlayersIdToAdd).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            // Act
+            var sut = BuildSUT();
+            sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+
+            // Assert
+            VerifyEditTeam(teamToEdit, Times.Once());
+            TestHelper.Equals(exeptedTeam, teamToEdit);
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method.
+        /// Should throw ArgumentException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_NotAllPlayerNew_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToAdd = CreateSeveralPlayersId();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var existingPlayersId = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(2),
+                new PlayerId(3),
+                new PlayerId(4)
+            };
+
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).WithRoster(existingPlayersId).Build();
+            var exeptedTeam = new TeamBuilder().WithRoster(testPlayersIdToAdd).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            Exception expectedExc = new ArgumentException(Resources.AddingMemberedPlayerToTeam);
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(gotException, expectedExc);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method. Try to add players with the same Id
+        /// Should throw ArgumentException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_AddDublicatePlayer_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToAdd = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(1),
+                new PlayerId(3),
+                new PlayerId(4)
+            };
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);          
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(gotException, expectedExc);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method. Try to add players with invalid Id
+        /// Should throw ArgumentException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_AddPlayerWithInvalidId_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToAdd = new List<PlayerId> {
+                new PlayerId(0),
+                new PlayerId(-7),
+                new PlayerId(3),
+                new PlayerId(4)
+            };
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(gotException, expectedExc);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method. Try to add players with invalid Id
+        /// Should throw ArgumentException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_AddPlayerWithNullId_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToAdd = new List<PlayerId> {
+                new PlayerId(3),
+                new PlayerId(4),
+                null
+            };
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(gotException, expectedExc);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method. Try to add null roster
+        /// Should throw ArgumentException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_NullRoster_ArgumentExceptionThrown()
+        {
+            // Arrange
+            IEnumerable<PlayerId> testPlayersIdToAdd = null;
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(gotException, expectedExc);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for AddPlayers() method. 
+        /// Should throw MissingEntityException
+        /// </summary>
+        [TestMethod]
+        public void AddPalyers_ToTeam_MissingEntityExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToAdd = CreateSeveralPlayersId();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var testTeam = new TeamBuilder().WithId(SPECIFIC_TEAM_ID + 1).Build();
+            _getTeamByIdQueryMock.Setup(tr => tr.Execute(It.Is<FindByIdCriteria>(cr => cr.Id == testTeam.Id))).Returns(testTeam);
+
+            // Act
+            var sut = BuildSUT();
+            var gotException = false;
+
+            try
+            {
+                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
+            }
+            catch (MissingEntityException)
+            {
+                gotException = true;
+            }
+
+            // Assert
+            Assert.IsTrue(gotException);
+            VerifyEditTeam(testTeam, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Try to remove players that no member of team
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_PlayersNotMemberOfTeam_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var playersIdToRemove = CreateSeveralPlayersId();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var existingPlayersId = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(2),
+                new PlayerId(3)
+            };
+            
+            var teamToEdit = new TeamBuilder().WithRoster(existingPlayersId).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.RemovingUnmemberedPlayerFromTeam, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Remove player with invalid id
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_InvalidPlayerId_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var playersIdToRemove = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(-7),
+                new PlayerId(3)
+            };
+
+            var teamToEdit = new TeamBuilder().Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Remove dublicate player
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_DublicatePlayerId_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var playersIdToRemove = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(1),
+                new PlayerId(3)
+            };
+
+            var teamToEdit = new TeamBuilder().Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Remove null playerId
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_PlayersWithNullId_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var playersIdToRemove = new List<PlayerId> {
+                new PlayerId(1),
+                null
+            };
+
+            var teamToEdit = new TeamBuilder().Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Null players
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_NullPlayers_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            IEnumerable<PlayerId> playersIdToRemove = null;
+
+            var teamToEdit = new TeamBuilder().Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. Remove captain
+        /// Should throw ArgumentExceptionThrown
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_RemoveCaptain_ArgumentExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var playersIdToRemove = new List<PlayerId> {
+                new PlayerId(SPECIFIC_PLAYER_ID)
+            };
+
+            var teamToEdit = new TeamBuilder().WithCaptain(new PlayerId(SPECIFIC_PLAYER_ID)).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            var exeptedExc = new ArgumentException(Resources.RemovingCaptain);
+
+            // Act
+            var sut = BuildSUT();
+            Exception gotException = null;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, playersIdToRemove);
+            }
+            catch (ArgumentException exc)
+            {
+                gotException = exc;
+            }
+
+            // Assert
+            VerifyExceptionThrown(exeptedExc, gotException);
+            VerifyEditTeam(teamToEdit, Times.Never());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method. 
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_AllPlayersRemove_TeamUpdated()
+        {
+            // Arrange
+            var playersIdToRemove = CreateSeveralPlayersId();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+
+            var existingPlayersId = new List<PlayerId> {
+                new PlayerId(1),
+                new PlayerId(2),
+                new PlayerId(3),
+                new PlayerId(4)
+            };
+
+            var exeptedPlayerId = new List<PlayerId> {
+                new PlayerId(1)
+            };
+
+            var teamToEdit = new TeamBuilder().WithRoster(existingPlayersId).Build();
+            var exeptedTeam = new TeamBuilder().WithRoster(exeptedPlayerId).Build();
+            MockGetTeamByIdQuery(teamToEdit);
+
+            // Act
+            var sut = BuildSUT();
+            sut.RemovePlayers(testTeamId, playersIdToRemove);
+
+            // Assert
+            VerifyEditTeam(teamToEdit, Times.Once());
+            TestHelper.Equals(exeptedTeam, teamToEdit);
+        }
+
+        /// <summary>
+        /// Test for FromPlayers() method. 
+        /// Should throw MissingEntityException
+        /// </summary>
+        [TestMethod]
+        public void RemovePalyers_FromTeam_MissingEntityExceptionThrown()
+        {
+            // Arrange
+            var testPlayersIdToRemove = new List<PlayerId>();
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var testTeam = new TeamBuilder().WithId(SPECIFIC_TEAM_ID + 1).Build();
+            _getTeamByIdQueryMock.Setup(tr => tr.Execute(It.Is<FindByIdCriteria>(cr => cr.Id == testTeam.Id))).Returns(testTeam);
+
+            // Act
+            var sut = BuildSUT();
+            var gotException = false;
+
+            try
+            {
+                sut.RemovePlayers(testTeamId, testPlayersIdToRemove);
+            }
+            catch (MissingEntityException)
+            {
+                gotException = true;
+            }
+
+            // Assert
+            Assert.IsTrue(gotException);
+            VerifyEditTeam(testTeam, Times.Never());
+        }
         #endregion
 
         #region Authorization team tests
@@ -1023,6 +1555,19 @@
             }
 
             return invalidTeamCoachName.ToString();
+        }
+
+        /// <summary>
+        /// Creates Team coach name with more number of symbols than it is allowed
+        /// </summary>
+        /// <returns>Invalid team coach name</returns>
+        private IEnumerable<PlayerId> CreateSeveralPlayersId()
+        {
+            var players = new List<PlayerId> {
+                new PlayerId(3),
+                new PlayerId(4)
+            };
+            return players;
         }
 
         /// <summary>

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -899,7 +899,7 @@
         /// Test for AddPlayers() method. 
         /// </summary>
         [TestMethod]
-        public void AddPalyers_AllPlayersAddedToTeam_TeamUpdated()
+        public void AddPlayers_AllPlayersAddedToTeam_TeamUpdated()
         {
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();
@@ -922,7 +922,7 @@
         /// Should throw MissingEntityException
         /// </summary>
         [TestMethod]
-        public void AddPalyers_AddPlayersToNotExistTeam_MissingEntityExceptionThrown()
+        public void AddPlayers_AddPlayersToNotExistTeam_MissingEntityExceptionThrown()
         {
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();
@@ -952,7 +952,7 @@
         /// Test for RemovePlayers() method. 
         /// </summary>
         [TestMethod]
-        public void RemovePalyers_AllPlayersRemoveFromTeam_TeamUpdated()
+        public void RemovePlayers_AllPlayersRemoveFromTeam_TeamUpdated()
         {
             // Arrange
             var playersIdToRemove = CreateSeveralPlayersId();
@@ -987,7 +987,7 @@
         /// Should throw MissingEntityException
         /// </summary>
         [TestMethod]
-        public void RemovePalyers_RemovePlayersFromNotExistTeam_MissingEntityExceptionThrown()
+        public void RemovePlayers_RemovePlayersFromNotExistTeam_MissingEntityExceptionThrown()
         {
             // Arrange
             var testPlayersIdToRemove = new List<PlayerId>();

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -834,7 +834,7 @@
             Assert.AreEqual(teamForEdit.Captain.Id, newCaptainId.Id);
         }
 
-        ///<summary>
+        /// <summary>
         /// Set captain of team player who does not have a team.
         /// Captain updated.
         /// </summary>

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -894,11 +894,12 @@
         #endregion
 
         #region Add and remove players
+
         /// <summary>
         /// Test for AddPlayers() method. 
         /// </summary>
         [TestMethod]
-        public void AddPalyers_ToTeam_AllPlayerNew_TeamUpdated()
+        public void AddPalyers_AllPlayersAddedToTeam_TeamUpdated()
         {
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();
@@ -917,11 +918,11 @@
         }
 
         /// <summary>
-        /// Test for AddPlayers() method. 
+        /// Test for AddPlayers() method. The method check if team with such id exist
         /// Should throw MissingEntityException
         /// </summary>
         [TestMethod]
-        public void AddPalyers_ToTeam_MissingEntityExceptionThrown()
+        public void AddPalyers_AddPlayersToNotExistTeam_MissingEntityExceptionThrown()
         {
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();
@@ -951,7 +952,7 @@
         /// Test for RemovePlayers() method. 
         /// </summary>
         [TestMethod]
-        public void RemovePalyers_FromTeam_AllPlayersRemove_TeamUpdated()
+        public void RemovePalyers_AllPlayersRemoveFromTeam_TeamUpdated()
         {
             // Arrange
             var playersIdToRemove = CreateSeveralPlayersId();
@@ -982,11 +983,11 @@
         }
 
         /// <summary>
-        /// Test for FromPlayers() method. 
+        /// Test for FromPlayers() method. The method check if team with such id exist
         /// Should throw MissingEntityException
         /// </summary>
         [TestMethod]
-        public void RemovePalyers_FromTeam_MissingEntityExceptionThrown()
+        public void RemovePalyers_RemovePlayersFromNotExistTeam_MissingEntityExceptionThrown()
         {
             // Arrange
             var testPlayersIdToRemove = new List<PlayerId>();

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -819,204 +819,17 @@
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();
             var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            var testTeam = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
             var exeptedTeam = new TeamBuilder().WithRoster(testPlayersIdToAdd).Build();
-            MockGetTeamByIdQuery(teamToEdit);
+            MockGetTeamByIdQuery(testTeam);
 
             // Act
             var sut = BuildSUT();
             sut.AddPlayers(testTeamId, testPlayersIdToAdd);
 
             // Assert
-            VerifyEditTeam(teamToEdit, Times.Once());
-            TestHelper.Equals(exeptedTeam, teamToEdit);
-        }
-
-        /// <summary>
-        /// Test for AddPlayers() method.
-        /// Should throw ArgumentException
-        /// </summary>
-        [TestMethod]
-        public void AddPalyers_ToTeam_NotAllPlayerNew_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testPlayersIdToAdd = CreateSeveralPlayersId();
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-            var existingPlayersId = new List<PlayerId> {
-                new PlayerId(1),
-                new PlayerId(2),
-                new PlayerId(3),
-                new PlayerId(4)
-            };
-
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).WithRoster(existingPlayersId).Build();
-            var exeptedTeam = new TeamBuilder().WithRoster(testPlayersIdToAdd).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            Exception expectedExc = new ArgumentException(Resources.AddingMemberedPlayerToTeam);
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(gotException, expectedExc);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for AddPlayers() method. Try to add players with the same Id
-        /// Should throw ArgumentException
-        /// </summary>
-        [TestMethod]
-        public void AddPalyers_ToTeam_AddDublicatePlayer_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testPlayersIdToAdd = new List<PlayerId> {
-                new PlayerId(1),
-                new PlayerId(1),
-                new PlayerId(3),
-                new PlayerId(4)
-            };
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);          
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(gotException, expectedExc);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for AddPlayers() method. Try to add players with invalid Id
-        /// Should throw ArgumentException
-        /// </summary>
-        [TestMethod]
-        public void AddPalyers_ToTeam_AddPlayerWithInvalidId_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testPlayersIdToAdd = new List<PlayerId> {
-                new PlayerId(0),
-                new PlayerId(-7),
-                new PlayerId(3),
-                new PlayerId(4)
-            };
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(gotException, expectedExc);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for AddPlayers() method. Try to add players with invalid Id
-        /// Should throw ArgumentException
-        /// </summary>
-        [TestMethod]
-        public void AddPalyers_ToTeam_AddPlayerWithNullId_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testPlayersIdToAdd = new List<PlayerId> {
-                new PlayerId(3),
-                new PlayerId(4),
-                null
-            };
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(gotException, expectedExc);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for AddPlayers() method. Try to add null roster
-        /// Should throw ArgumentException
-        /// </summary>
-        [TestMethod]
-        public void AddPalyers_ToTeam_NullRoster_ArgumentExceptionThrown()
-        {
-            // Arrange
-            IEnumerable<PlayerId> testPlayersIdToAdd = null;
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-            var teamToEdit = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            Exception expectedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.AddPlayers(testTeamId, testPlayersIdToAdd);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(gotException, expectedExc);
-            VerifyEditTeam(teamToEdit, Times.Never());
+            VerifyEditTeam(testTeam, Times.Once());
+            TestHelper.Equals(exeptedTeam, testTeam);
         }
 
         /// <summary>
@@ -1051,234 +864,6 @@
         }
 
         /// <summary>
-        /// Test for RemovePlayers() method. Try to remove players that no member of team
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_PlayersNotMemberOfTeam_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var playersIdToRemove = CreateSeveralPlayersId();
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            var existingPlayersId = new List<PlayerId> {
-                new PlayerId(1),
-                new PlayerId(2),
-                new PlayerId(3)
-            };
-            
-            var teamToEdit = new TeamBuilder().WithRoster(existingPlayersId).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.RemovingUnmemberedPlayerFromTeam, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for RemovePlayers() method. Remove player with invalid id
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_InvalidPlayerId_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            var playersIdToRemove = new List<PlayerId> {
-                new PlayerId(1),
-                new PlayerId(-7),
-                new PlayerId(3)
-            };
-
-            var teamToEdit = new TeamBuilder().Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for RemovePlayers() method. Remove dublicate player
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_DublicatePlayerId_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            var playersIdToRemove = new List<PlayerId> {
-                new PlayerId(1),
-                new PlayerId(1),
-                new PlayerId(3)
-            };
-
-            var teamToEdit = new TeamBuilder().Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for RemovePlayers() method. Remove null playerId
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_PlayersWithNullId_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            var playersIdToRemove = new List<PlayerId> {
-                new PlayerId(1),
-                null
-            };
-
-            var teamToEdit = new TeamBuilder().Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for RemovePlayers() method. Null players
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_NullPlayers_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            IEnumerable<PlayerId> playersIdToRemove = null;
-
-            var teamToEdit = new TeamBuilder().Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.ValidationTeamRoster, "players");
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
-        /// Test for RemovePlayers() method. Remove captain
-        /// Should throw ArgumentExceptionThrown
-        /// </summary>
-        [TestMethod]
-        public void RemovePalyers_FromTeam_RemoveCaptain_ArgumentExceptionThrown()
-        {
-            // Arrange
-            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
-
-            var playersIdToRemove = new List<PlayerId> {
-                new PlayerId(SPECIFIC_PLAYER_ID)
-            };
-
-            var teamToEdit = new TeamBuilder().WithCaptain(new PlayerId(SPECIFIC_PLAYER_ID)).Build();
-            MockGetTeamByIdQuery(teamToEdit);
-
-            var exeptedExc = new ArgumentException(Resources.RemovingCaptain);
-
-            // Act
-            var sut = BuildSUT();
-            Exception gotException = null;
-
-            try
-            {
-                sut.RemovePlayers(testTeamId, playersIdToRemove);
-            }
-            catch (ArgumentException exc)
-            {
-                gotException = exc;
-            }
-
-            // Assert
-            VerifyExceptionThrown(exeptedExc, gotException);
-            VerifyEditTeam(teamToEdit, Times.Never());
-        }
-
-        /// <summary>
         /// Test for RemovePlayers() method. 
         /// </summary>
         [TestMethod]
@@ -1299,17 +884,17 @@
                 new PlayerId(1)
             };
 
-            var teamToEdit = new TeamBuilder().WithRoster(existingPlayersId).Build();
+            var testTeam = new TeamBuilder().WithRoster(existingPlayersId).Build();
             var exeptedTeam = new TeamBuilder().WithRoster(exeptedPlayerId).Build();
-            MockGetTeamByIdQuery(teamToEdit);
+            MockGetTeamByIdQuery(testTeam);
 
             // Act
             var sut = BuildSUT();
             sut.RemovePlayers(testTeamId, playersIdToRemove);
 
             // Assert
-            VerifyEditTeam(teamToEdit, Times.Once());
-            TestHelper.Equals(exeptedTeam, teamToEdit);
+            VerifyEditTeam(testTeam, Times.Once());
+            TestHelper.Equals(exeptedTeam, testTeam);
         }
 
         /// <summary>
@@ -1412,6 +997,53 @@
             VerifyCheckAccess(AuthOperations.Teams.Edit, Times.Once());
         }
 
+        /// <summary>
+        /// Test for AddPlayers() method with no permission for such action. The method has to throw AuthorizationException,
+        /// should invoke CheckAccess() and shouldn't invoke Commit() method of IUnitOfWork
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(AuthorizationException))]
+        public void AddPlayers_AddPlayersNotPermitted_ExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var testPlayersId = CreateSeveralPlayersId();
+            var testTeam = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockAuthServiceThrowsExeption(AuthOperations.Teams.Edit);
+
+            var sut = BuildSUT();
+
+            // Act
+            sut.AddPlayers(testTeamId, testPlayersId);
+
+            // Assert
+            VerifyEditTeam(testTeam, Times.Never());
+            VerifyCheckAccess(AuthOperations.Teams.Edit, Times.Once());
+        }
+
+        /// <summary>
+        /// Test for RemovePlayers() method with no permission for such action. The method has to throw AuthorizationException,
+        /// should invoke CheckAccess() and shouldn't invoke Commit() method of IUnitOfWork
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(AuthorizationException))]
+        public void RemovePlayers_RemovePlayersNotPermitted_ExceptionThrown()
+        {
+            // Arrange
+            var testTeamId = new TeamId(SPECIFIC_TEAM_ID);
+            var testPlayersId = CreateSeveralPlayersId();
+            var testTeam = new TeamBuilder().WithId(SPECIFIC_TEAM_ID).Build();
+            MockAuthServiceThrowsExeption(AuthOperations.Teams.Edit);
+
+            var sut = BuildSUT();
+
+            // Act
+            sut.RemovePlayers(testTeamId, testPlayersId);
+
+            // Assert
+            VerifyEditTeam(testTeam, Times.Never());
+            VerifyCheckAccess(AuthOperations.Teams.Edit, Times.Once());
+        }
         #endregion
 
         #endregion

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -899,7 +899,7 @@
         /// Test for AddPlayers() method. 
         /// </summary>
         [TestMethod]
-        public void AddPlayers_AllPlayersAddedToTeam_TeamUpdated()
+        public void AddPlayers_PlayersAddedToTeam_TeamUpdated()
         {
             // Arrange
             var testPlayersIdToAdd = CreateSeveralPlayersId();

--- a/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
+++ b/tests/VolleyManagement.UnitTests/Services/TeamService/TeamServiceTests.cs
@@ -834,7 +834,8 @@
             Assert.AreEqual(teamForEdit.Captain.Id, newCaptainId.Id);
         }
 
-         /// Set captain of team player who does not have a team.
+        ///<summary>
+        /// Set captain of team player who does not have a team.
         /// Captain updated.
         /// </summary>
         [TestMethod]
@@ -879,7 +880,7 @@
 
             try
             {
-                 sut.ChangeCaptain(teamForEditId, newCaptainId);
+                sut.ChangeCaptain(teamForEditId, newCaptainId);
             }
             catch (ValidationException)
             {
@@ -891,7 +892,8 @@
             VerifyEditTeam(teamForEdit, Times.Never());
         }
         #endregion
-          
+
+        #region Add and remove players
         /// <summary>
         /// Test for AddPlayers() method. 
         /// </summary>
@@ -1008,8 +1010,7 @@
             Assert.IsTrue(gotException);
             VerifyEditTeam(testTeam, Times.Never());
         }
-  
-       
+        #endregion
 
         #region Authorization team tests
 


### PR DESCRIPTION
### Summary

Add test for AddPlayers and RemovePlayers in TeamService

closes #353

### Areas Of Interest

### Checklist

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Naming: Initial state and expected result are properly stated
- [ ] Test follows [AAA](https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80) pattern.
- [ ] Test is Isolated
- [ ] Mock instances and expected instances do not share references
- [ ] When new property is added all related comparers are updated
