### PR TITLE
[AB#1082] refactor create user

### DIFF
--- a/src/Client/VolleyM.API/Extensions/DiExtensions.cs
+++ b/src/Client/VolleyM.API/Extensions/DiExtensions.cs
@@ -41,7 +41,7 @@ namespace VolleyM.API.Extensions
             var mc = new MapperConfiguration(mce);
             mc.AssertConfigurationIsValid();
 
-            container.RegisterSingleton(() => new Mapper(mc, container.GetInstance));
+            container.RegisterSingleton<IMapper>(() => new Mapper(mc, container.GetInstance));
         }
     }
 }

--- a/src/Domain/VolleyM.Domain.Contracts/IdBase.cs
+++ b/src/Domain/VolleyM.Domain.Contracts/IdBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace VolleyM.Domain.Contracts
 {
-    public abstract class IdBase<TUnderlyingType>:IEquatable<IdBase<TUnderlyingType>>
+    public abstract class IdBase<TUnderlyingType> : IEquatable<IdBase<TUnderlyingType>>
     {
         private readonly TUnderlyingType _value;
 
@@ -47,12 +47,34 @@ namespace VolleyM.Domain.Contracts
                 return false;
             }
 
-            return Equals((IdBase<TUnderlyingType>) obj);
+            return Equals((IdBase<TUnderlyingType>)obj);
         }
 
         public override int GetHashCode()
         {
             return EqualityComparer<TUnderlyingType>.Default.GetHashCode(_value);
+        }
+
+        public static bool operator ==(IdBase<TUnderlyingType> left, IdBase<TUnderlyingType> right)
+        {
+            if (ReferenceEquals(null, left) && ReferenceEquals(null, right))
+                return false;
+
+            if (!ReferenceEquals(null, left))
+                return left.Equals(right);
+
+            return false;
+        }
+
+        public static bool operator !=(IdBase<TUnderlyingType> left, IdBase<TUnderlyingType> right)
+        {
+            if (ReferenceEquals(null, left) && ReferenceEquals(null, right))
+                return true;
+
+            if (!ReferenceEquals(null, left))
+                return !left.Equals(right);
+
+            return true;
         }
     }
 }

--- a/src/Domain/VolleyM.Domain.IdentityAndAccess/DomainContributorsAssemblyBootstrapper.cs
+++ b/src/Domain/VolleyM.Domain.IdentityAndAccess/DomainContributorsAssemblyBootstrapper.cs
@@ -13,6 +13,8 @@ namespace VolleyM.Domain.IdentityAndAccess
         public void RegisterDependencies(Container container, Microsoft.Extensions.Configuration.IConfiguration config)
         {
             container.Register(typeof(IRequestHandler<,>), Assembly.GetAssembly(GetType()), Lifestyle.Scoped);
+
+            container.Register<UserFactory>(Lifestyle.Singleton);
         }
 
         public void RegisterMappingProfiles(MapperConfigurationExpression mce)

--- a/src/Domain/VolleyM.Domain.IdentityAndAccess/Handlers/CreateUser.cs
+++ b/src/Domain/VolleyM.Domain.IdentityAndAccess/Handlers/CreateUser.cs
@@ -31,17 +31,15 @@ namespace VolleyM.Domain.IdentityAndAccess.Handlers
 
             public async Task<Result<User>> Handle(Request request)
             {
-                var existing = await _repository.Get(request.Tenant, request.UserId);
-
-                if (existing.IsSuccessful)
+                var user = new User(request.UserId, request.Tenant);
+                if (request.Role != null)
                 {
-                    return Error.Conflict();
+                    user.AssignRole(request.Role);
                 }
 
-                var user = new User(request.UserId, request.Tenant);
+                var addResult = await _repository.Add(user);
 
-                //FIXME: Assign ROle
-                return await _repository.Add(user);
+                return addResult;
             }
         }
     }

--- a/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/User.cs
+++ b/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/User.cs
@@ -11,6 +11,12 @@ namespace VolleyM.Domain.IdentityAndAccess
             Tenant = tenant;
         }
 
+        internal User(UserFactoryDto userDto)
+            : this(userDto.Id, userDto.Tenant)
+        {
+            Role = userDto.Role;
+        }
+
         public UserId Id { get; }
 
         public TenantId Tenant { get; }

--- a/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/UserFactory.cs
+++ b/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/UserFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace VolleyM.Domain.IdentityAndAccess
+{
+    /// <summary>
+    /// Creates user instances from persistent state
+    /// </summary>
+    public sealed class UserFactory
+    {
+        public User CreateUser(UserFactoryDto userDto)
+        {
+            if (userDto == null)
+            {
+                throw new ArgumentNullException(nameof(userDto));
+            }
+            return new User(userDto);
+        }
+    }
+}

--- a/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/UserFactoryDto.cs
+++ b/src/Domain/VolleyM.Domain.IdentityAndAccess/UserAggregate/UserFactoryDto.cs
@@ -1,0 +1,15 @@
+﻿using VolleyM.Domain.Contracts;
+using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
+
+namespace VolleyM.Domain.IdentityAndAccess
+{
+    /// <summary>
+    /// Data object to reconstruct User state from persistence
+    /// </summary>
+    public class UserFactoryDto
+    {
+        public UserId Id { get; set; }
+        public TenantId Tenant { get; set; }
+        public RoleId Role { get; set; }
+    }
+}

--- a/src/Infrastructure/VolleyM.Infrastructure.IdentityAndAccess.AzureStorage/InfrastructureIdentityAndAccessAzureStorageBootstrapper.cs
+++ b/src/Infrastructure/VolleyM.Infrastructure.IdentityAndAccess.AzureStorage/InfrastructureIdentityAndAccessAzureStorageBootstrapper.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.Configuration;
 using SimpleInjector;
 using System.Composition;
+using VolleyM.Domain.Contracts;
 using VolleyM.Domain.IdentityAndAccess;
+using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
 using VolleyM.Infrastructure.Bootstrap;
 using VolleyM.Infrastructure.IdentityAndAccess.AzureStorage.TableConfiguration;
 
@@ -23,7 +25,17 @@ namespace VolleyM.Infrastructure.IdentityAndAccess.AzureStorage
 
         public void RegisterMappingProfiles(MapperConfigurationExpression mce)
         {
-            //no mapping
+            mce.CreateMap<UserEntity, UserFactoryDto>()
+                .ForMember(m => m.Id,
+                    m => m.MapFrom(src => new UserId(src.RowKey)))
+                .ForMember(m => m.Tenant,
+                    m => m.MapFrom(src => new TenantId(src.PartitionKey)))
+                .ForMember(m => m.Role,
+                    m =>
+                    {
+                        m.Condition(src => !string.IsNullOrEmpty(src.RoleId));
+                        m.MapFrom(src => new RoleId(src.RoleId));
+                    });
         }
     }
 }

--- a/src/Infrastructure/VolleyM.Infrastructure.IdentityAndAccess.AzureStorage/UserEntity.cs
+++ b/src/Infrastructure/VolleyM.Infrastructure.IdentityAndAccess.AzureStorage/UserEntity.cs
@@ -1,18 +1,21 @@
 ﻿using Microsoft.Azure.Cosmos.Table;
 using VolleyM.Domain.Contracts;
 using VolleyM.Domain.IdentityAndAccess;
+using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
 
 namespace VolleyM.Infrastructure.IdentityAndAccess.AzureStorage
 {
     public class UserEntity : TableEntity
     {
+        public string RoleId { get; set; }
+
         public UserEntity()
         {
 
         }
 
         public UserEntity(User user)
-        : this(user.Tenant, user.Id)
+        : this(user.Tenant, user.Id, user.Role)
         {
         }
 
@@ -20,6 +23,14 @@ namespace VolleyM.Infrastructure.IdentityAndAccess.AzureStorage
         {
             PartitionKey = tenant.ToString();
             RowKey = id.ToString();
+        }
+
+        public UserEntity(TenantId tenant, UserId id, RoleId role)
+        {
+            PartitionKey = tenant.ToString();
+            RowKey = id.ToString();
+
+            RoleId = role?.ToString();
         }
     }
 }

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Fixture/UserBuilder.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Fixture/UserBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using VolleyM.Domain.Contracts;
+using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
 
 namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
 {
@@ -7,6 +8,7 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
     {
         private UserId _id;
         private TenantId _tenant;
+        private RoleId _role;
 
         private UserBuilder()
         { }
@@ -18,7 +20,11 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
 
         public User Build()
         {
-            return new User(_id, _tenant);
+            var result = new User(_id, _tenant);
+            if (_role != null)
+                result.AssignRole(_role);
+
+            return result;
         }
 
         public UserBuilder WithId(UserId id)
@@ -26,6 +32,9 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
 
         public UserBuilder WithTenant(TenantId tenant)
             => With(() => { _tenant = tenant; });
+
+        public void WithRole(RoleId role)
+            => With(() => { _role = role; });
 
         private UserBuilder With(Action action)
         {

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUser.feature
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUser.feature
@@ -7,9 +7,11 @@ But we still need a minimal feature to have users referenced in authorization po
 Scenario: Create new user
 	Given UserId provided
     And Tenant provided
+	And Role provided
     And user does not exist
 	When I execute CreateUser
 	Then user is created
+	And user is returned
 
 @unit @azurecloud @ab:1026
 Scenario: Create existing user
@@ -18,3 +20,12 @@ Scenario: Create existing user
     And such user already exists
     When I execute CreateUser
     Then Conflict error is returned
+
+@unit @azurecloud @ab:1026
+Scenario: Create new without Role
+	Given UserId provided
+    And Tenant provided
+    And user does not exist
+	When I execute CreateUser
+	Then user is created
+	And user is returned

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentAssertions;
 using VolleyM.Domain.Contracts;
 using VolleyM.Domain.IdentityAndAccess.Handlers;
+using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
 using VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture;
 using Xunit.Gherkin.Quick;
 
@@ -12,6 +14,7 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests
     {
         private readonly UserId _aUserId = new UserId("google|123321");
         private readonly TenantId _aTenantId = new TenantId("auto-tests-tenant");
+        private readonly RoleId _aRoleId = new RoleId("roleA");
 
         private readonly IdentityAndAccessFixture _fixture;
 
@@ -57,6 +60,13 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests
             _expectedUser.WithTenant(_aTenantId);
         }
 
+        [And("Role provided")]
+        public void AndRoleProvided()
+        {
+            _request.Role = _aRoleId;
+            _expectedUser.WithRole(_aRoleId);
+        }
+
         [And("such user already exists")]
         public void AndUserExists()
         {
@@ -90,6 +100,13 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests
         public void ThenConflictErrorReturned()
         {
             AssertErrorReturned(_actualResult, Error.Conflict(), "such user already exists");
+        }
+
+        [And("user is returned")]
+        public void AndUserIsReturned()
+        {
+            _actualResult.Value.Should()
+                .BeEquivalentTo(_expectedUser.Build(), "created user should be returned");
         }
     }
 }

--- a/tests/unit-tests/VolleyM.Domain.UnitTests.Framework/DomainStepsBase.cs
+++ b/tests/unit-tests/VolleyM.Domain.UnitTests.Framework/DomainStepsBase.cs
@@ -2,6 +2,8 @@
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
 using System;
+using AutoMapper;
+using AutoMapper.Configuration;
 using VolleyM.Domain.Contracts;
 using Xunit.Gherkin.Quick;
 
@@ -18,10 +20,20 @@ namespace VolleyM.Domain.UnitTests.Framework
             _container = new Container();
             _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
 
+
+            var mce = new MapperConfigurationExpression();
+            mce.ConstructServicesUsing(_container.GetInstance);
+
             foreach (var bootstrapper in fixture.GetBootstrappers())
             {
                 bootstrapper.RegisterDependencies(_container, fixture.Configuration);
+                bootstrapper.RegisterMappingProfiles(mce);
             }
+
+            var mc = new MapperConfiguration(mce);
+            mc.AssertConfigurationIsValid();
+
+            _container.RegisterSingleton<IMapper>(() => new Mapper(mc, _container.GetInstance));
 
             _scope = AsyncScopedLifestyle.BeginScope(_container);
 


### PR DESCRIPTION
### Summary

Simplified create a user. Now it also returns a created object.

### Areas Of Interest

Create user does not query for existing users anymore to prevent race conditions.
Introduced factory to reconstitute domain objects from persistence.

### Checklist

- [ ] Logger logs all newly added types correctly

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [x] Tests have appropriate category set: `@unit`, `@azurecloud`, `@onpremsql`
- [x] Story/bug tag is assigned to created/affected test: `@ab:123`
- [x] Tests resolve `IRequestHandler<,>` instance instead of concrete implementation

#### Integration Tests

- [ ] Teardown deletes test data after each test

### New Project Checklist

- [ ] Dockerfile is updated
- [ ] Azure Pipelines updated
- [ ] Development setup guide updated
- [ ] VolleyM.API has reference added to assist debugging
- [ ] Project added into required migrations

### Azure Storage

If new table added:

- [ ] Update settings for all Environments
- [ ] Update settings for integration tests
