### PR TITLE
Bump SimpleInjector.Integration.AspNetCore.Mvc.Core from 4.10.3 to 5.0.0

### DIFF
--- a/src/Client/VolleyM.API/VolleyM.API.csproj
+++ b/src/Client/VolleyM.API/VolleyM.API.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore" Version="4.10.3" />
-    <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="4.10.3" />
+    <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps SimpleInjector.Integration.AspNetCore.Mvc.Core from 4.10.3 to 5.0.0.

Signed-off-by: dependabot[bot] <support@github.com>