### PR TITLE
Bump SpecFlow.Tools.MsBuild.Generation from 3.1.97 to 3.3.30

### DIFF
--- a/tests/unit-tests/VolleyM.Domain.Contributors.UnitTests/VolleyM.Domain.Contributors.UnitTests.csproj
+++ b/tests/unit-tests/VolleyM.Domain.Contributors.UnitTests/VolleyM.Domain.Contributors.UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
     <PackageReference Include="SpecFlow" Version="3.1.97" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/VolleyM.Domain.Framework.UnitTests.csproj
+++ b/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/VolleyM.Domain.Framework.UnitTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
     <PackageReference Include="SpecFlow" Version="3.1.97" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/VolleyM.Domain.IdentityAndAccess.UnitTests.csproj
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/VolleyM.Domain.IdentityAndAccess.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
     <PackageReference Include="SpecFlow" Version="3.1.97" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/unit-tests/VolleyM.Domain.Players.UnitTests/VolleyM.Domain.Players.UnitTests.csproj
+++ b/tests/unit-tests/VolleyM.Domain.Players.UnitTests/VolleyM.Domain.Players.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="SpecFlow" Version="3.1.97" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/unit-tests/VolleyM.Infrastructure.EventBroker.UnitTests/VolleyM.Infrastructure.EventBroker.UnitTests.csproj
+++ b/tests/unit-tests/VolleyM.Infrastructure.EventBroker.UnitTests/VolleyM.Infrastructure.EventBroker.UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
     <PackageReference Include="SpecFlow" Version="3.1.97" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">


### PR DESCRIPTION
Bumps SpecFlow.Tools.MsBuild.Generation from 3.1.97 to 3.3.30.

Signed-off-by: dependabot[bot] <support@github.com>
