### PR TITLE
[#532] Better Either Assertions

### DIFF
--- a/karate-tests.code-workspace
+++ b/karate-tests.code-workspace
@@ -19,9 +19,7 @@
 			"titleBar.inactiveForeground": "#e7e7e799",
 			"statusBar.background": "#2089b3",
 			"statusBarItem.hoverBackground": "#2da8d9",
-			"statusBar.foreground": "#e7e7e7",
-			"statusBar.border": "#2089b3",
-			"titleBar.border": "#2089b3"
+			"statusBar.foreground": "#e7e7e7"
 		},
 		"peacock.color": "#2089b3",
 		"karateRunner.karateJar.commandLineArgs": "java -cp ${workspaceRoot}\\karate.jar com.intuit.karate.Main -e dev",

--- a/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/Authorization/AuthorizeUserSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/Authorization/AuthorizeUserSteps.cs
@@ -14,7 +14,7 @@ using VolleyM.Domain.Framework.Authorization;
 using VolleyM.Domain.IdentityAndAccess;
 using VolleyM.Domain.IdentityAndAccess.Handlers;
 using VolleyM.Domain.IdentityAndAccess.RolesAggregate;
-
+using VolleyM.Domain.UnitTests.Framework;
 using Constants = VolleyM.Domain.UnitTests.Framework.Constants;
 
 namespace VolleyM.Domain.Framework.UnitTests.Authorization
@@ -152,7 +152,7 @@ namespace VolleyM.Domain.Framework.UnitTests.Authorization
 		[Then("user should be authorized")]
 		public void ThenUserShouldBeAuthorized()
 		{
-			_actualResult.IsRight.Should().BeTrue("user should be authorized");
+			_actualResult.ShouldBeEquivalent(Unit.Default, "user should be authorized");
 		}
 
 		[Then("user should not be authorized")]

--- a/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/AuthorizationHandlerDecorator/AuthorizationDecoratorSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/AuthorizationHandlerDecorator/AuthorizationDecoratorSteps.cs
@@ -68,7 +68,7 @@ namespace VolleyM.Domain.Framework.UnitTests.AuthorizationHandlerDecorator
         [Then(@"success result is returned")]
         public void ThenReturnsSuccess()
         {
-            _actualResult.IsRight.Should().BeTrue("user has required permission");
+			_actualResult.ShouldBeEquivalent(Unit.Default, "user has required permission");
         }
 
         private void RegisterHandlers()

--- a/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/HandlerStructure/ValidatorLocatorSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.Framework.UnitTests/HandlerStructure/ValidatorLocatorSteps.cs
@@ -48,7 +48,7 @@ namespace VolleyM.Domain.Framework.UnitTests.HandlerStructure
         }
 
         [Then(@"(.*) is returned")]
-        public void ThenFalseIsReturned(bool result)
+        public void ThenResultIsReturned(bool result)
         {
             _actualResult.Should().Be(result);
         }

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Fixture/AzureCloudIdentityAndAccessFixture.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Fixture/AzureCloudIdentityAndAccessFixture.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using SimpleInjector;
 using VolleyM.Domain.Contracts;
+using VolleyM.Domain.UnitTests.Framework;
 
 namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
 {
@@ -54,8 +55,7 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Fixture
 
             var savedUser = await repo.Get(user.Tenant, user.Id).ToEither();
 
-            savedUser.IsRight.Should().BeTrue("user should be created");
-            savedUser.IfRight(u => u.Should().BeEquivalentTo(user, "all attributes should be saved correctly"));
+			savedUser.ShouldBeEquivalent(user, "all attributes should be saved correctly");
         }
 
         private async Task CleanUpUsers(IEnumerable<Tuple<TenantId, UserId>> usersToTeardown)

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
@@ -98,6 +98,7 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Users
         [Then("Conflict error is returned")]
         public void ThenConflictErrorReturned()
         {
+			AssertionOptions.EquivalencySteps
             _actualResult.ShouldBeError(Error.Conflict(), "such user already exists");
         }
 

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/CreateUserSteps.cs
@@ -98,16 +98,13 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests.Users
         [Then("Conflict error is returned")]
         public void ThenConflictErrorReturned()
         {
-			AssertionOptions.EquivalencySteps
             _actualResult.ShouldBeError(Error.Conflict(), "such user already exists");
         }
 
         [Then("user is returned")]
         public void ThenUserIsReturned()
         {
-            _actualResult.IsRight.Should().BeTrue("created user should be returned");
-            _actualResult.IfRight(u => u.Should()
-                .BeEquivalentTo(_expectedUser.Build(), "created user should be returned"));
+			_actualResult.ShouldBeEquivalent(_expectedUser.Build(), "created user should be returned");
         }
     }
 }

--- a/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/GetUserSteps.cs
+++ b/tests/unit-tests/VolleyM.Domain.IdentityAndAccess.UnitTests/Users/GetUserSteps.cs
@@ -82,8 +82,7 @@ namespace VolleyM.Domain.IdentityAndAccess.UnitTests
         [Then("user is returned")]
         public void ThenUserIsReturned()
         {
-            _actualResult.IsRight.Should().BeTrue("user exists");
-            _actualResult.IfRight(u => u.Should().BeEquivalentTo(_expectedUser, "all user attributes should be returned"));
+	        _actualResult.ShouldBeEquivalent(_expectedUser, "all user attributes should be returned");
         }
 
         [Then("NotFound error is returned")]

--- a/tests/unit-tests/VolleyM.Domain.Players.UnitTests/Fixture/AzureCloudPlayersTestFixture.cs
+++ b/tests/unit-tests/VolleyM.Domain.Players.UnitTests/Fixture/AzureCloudPlayersTestFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using VolleyM.Domain.Contracts;
 using VolleyM.Domain.Players.PlayerAggregate;
 using VolleyM.Domain.Players.UnitTests.Fixture;
+using VolleyM.Domain.UnitTests.Framework;
 
 namespace VolleyM.Domain.Players.UnitTests
 {
@@ -46,8 +47,7 @@ namespace VolleyM.Domain.Players.UnitTests
 
 			var savedPlayer = await repo.Get(expectedPlayer.Tenant, expectedPlayer.Id).ToEither();
 
-			savedPlayer.IsRight.Should().BeTrue("player should be created");
-			savedPlayer.IfRight(u => u.Should().BeEquivalentTo(expectedPlayer, "all attributes should be saved correctly"));
+			savedPlayer.ShouldBeEquivalent(expectedPlayer, "all attributes should be saved correctly");
 
 			_playersToTeardown.Add((expectedPlayer.Tenant, expectedPlayer.Id));
 		}
@@ -58,8 +58,7 @@ namespace VolleyM.Domain.Players.UnitTests
 
 			var savedPlayer = await repo.Get(expectedPlayer.Tenant, expectedPlayer.Id).ToEither();
 
-			savedPlayer.IsRight.Should().BeFalse("player should not be created");
-			savedPlayer.IfLeft(u => u.Should().BeEquivalentTo(Error.NotFound(), "NotFound error is expected"));
+			savedPlayer.ShouldBeError(Error.NotFound(), "NotFound error is expected");
 		}
 
 		private async Task CleanUpPlayers()

--- a/tests/unit-tests/VolleyM.Domain.Players.UnitTests/Fixture/UnitPlayersTestFixture.cs
+++ b/tests/unit-tests/VolleyM.Domain.Players.UnitTests/Fixture/UnitPlayersTestFixture.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
 using FluentAssertions;
 using NSubstitute;
 using SimpleInjector;

--- a/tests/unit-tests/VolleyM.Domain.UnitTests.Framework/TestExtensions.cs
+++ b/tests/unit-tests/VolleyM.Domain.UnitTests.Framework/TestExtensions.cs
@@ -1,39 +1,85 @@
 ﻿using FluentAssertions;
+using FluentAssertions.Execution;
 using LanguageExt;
+using LanguageExt.SomeHelp;
 using VolleyM.Domain.Contracts;
 
 namespace VolleyM.Domain.UnitTests.Framework
 {
-    public static class TestExtensions
-    {
-        public static void ShouldBeError<T>(
-            this Either<Error, T> actualResult,
-            Error expected,
-            string because = "error should be reported",
-            params object[] becauseArgs)
-        {
-            actualResult.IsLeft.Should().BeTrue("error is expected");
-            actualResult.IfLeft(e => e.Should().BeEquivalentTo(expected, because, becauseArgs));
-        }
+	public static class TestExtensions
+	{
+		public static EitherAssertions<TLeft, TRight> Should<TLeft, TRight>(this Either<TLeft, TRight> either)
+		{
+			return new EitherAssertions<TLeft, TRight>(either);
+		}
 
-        public static void ShouldBeError<T>(
-            this Either<Error, T> actualResult,
-            ErrorType expectedType,
-            string because = "error should be reported",
-            params object[] becauseArgs)
-        {
-            actualResult.IsLeft.Should().BeTrue("error is expected");
-            actualResult.IfLeft(e => e.Type.Should().BeEquivalentTo(expectedType, because, becauseArgs));
-        }
+		public static void ShouldBeError<T>(
+			this Either<Error, T> actualResult,
+			Error expected,
+			string because = "error should be reported",
+			params object[] becauseArgs)
+		{
+			//actualResult.IsLeft.Should().BeTrue("error is expected");
+			//actualResult.IfLeft(e => e.Should().BeEquivalentTo(expected, because, becauseArgs));
 
-        public static void ShouldBeEquivalent<T>(
-            this Either<Error, T> actualResult,
-            object expected,
-            string because = "",
-            params object[] becauseArgs)
-        {
-            actualResult.IsRight.Should().BeTrue("successful result is expected");
-            actualResult.IfRight(v => v.Should().BeEquivalentTo(expected, because, becauseArgs));
-        }
-    }
+			var p = (Either<Error, T>)expected;
+
+			actualResult.Should().BeEquivalentTo(p, because, becauseArgs);
+		}
+
+		public static void ShouldBeError<T>(
+			this Either<Error, T> actualResult,
+			ErrorType expectedType,
+			string because = "error should be reported",
+			params object[] becauseArgs)
+		{
+			actualResult.IsLeft.Should().BeTrue("error is expected");
+			actualResult.IfLeft(e => e.Type.Should().BeEquivalentTo(expectedType, because, becauseArgs));
+		}
+
+		public static void ShouldBeEquivalent<T>(
+			this Either<Error, T> actualResult,
+			object expected,
+			string because = "",
+			params object[] becauseArgs)
+		{
+			//actualResult.IsRight.Should().BeTrue("successful result is expected");
+			//actualResult.IfRight(v => v.Should().BeEquivalentTo(expected, because, becauseArgs));
+
+			//var p = (Either<Error, T>)expected;
+
+
+			actualResult.Should().BeEquivalentTo(expected, because, becauseArgs);
+		}
+	}
+
+	public class EitherAssertions<TLeft, TRight>
+	{
+		private readonly Either<TLeft, TRight> _instance;
+
+		public EitherAssertions(Either<TLeft, TRight> instance)
+		{
+			_instance = instance;
+		}
+
+		public AndConstraint<EitherAssertions<TLeft1, TRight1>> BeError<TLeft1, TRight1>(
+			Error expected,
+			string because = "error should be reported",
+			params object[] becauseArgs) where TLeft1 : Error
+		{
+			Execute.Assertion
+				.BecauseOf(because, becauseArgs)
+				.ForCondition(_instance.IsLeft)
+				.FailWith("error should be reported")
+				.Then
+				.Given(() => _instance.Match<Error>(r => default(Error), l => (Error) l))
+				.ForCondition(left =>
+				{
+					left.Should().Be(expected);
+					return true;
+				});
+
+			return new AndConstraint<EitherAssertions<TLeft1, TRight1>>(this);
+		}
+	}
 }


### PR DESCRIPTION
### Summary

Closes #532 

- Refactored extension methods for Either assertions

### Checklist

- [ ] Logger logs all newly added types correctly
- [ ] New feature is hidden behind feature flag

#### Design

- [ ] Web API layer contains as little logic as possible
- [ ] Domain objects use semantic names

#### Perfromance

- [ ] In case of any DB query was changed: attach generated SQL for review
- [ ] Number of DB roundtrips should be as low as possible

#### Unit Tests

- [ ] Tests have appropriate category set: `@unit`, `@azurecloud`, `@onpremsql`
- [ ] Story/bug tag is assigned to created/affected test: `@ab:123`
- [ ] Tests resolve `IRequestHandler<,>` instance instead of concrete implementation
- [ ] Step definition class has `Scope` attribute
- [ ] Each scenario should use unique entity ID to avoid issues as tests run in parallel

#### Integration Tests

- [ ] Teardown deletes test data after each test

### New Project Checklist

- [ ] Dockerfile is updated
- [ ] Azure Pipelines updated
- [ ] Development setup guide updated
- [ ] VolleyM.API has reference added to assist debugging
- [ ] Project added into required migrations

### Azure Storage

If new table added:

- [ ] Update settings for all Environments
- [ ] Update settings for integration tests
